### PR TITLE
Only build tests/executable when in a root project

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -147,7 +147,6 @@ if tracy_dep.found()
     deps += tracy_dep
 endif
 
-
 python3 = find_program('python3', required: false)
 
 meson_proj = dependency('', required: false)
@@ -158,8 +157,8 @@ if python3.found() and get_option('website')
     c_args += ['-DHAVE_MESON_DOCS_H']
 endif
 
-
-muon_lib = library('muon',
+muon_lib = library(
+    'muon',
     lib_src,
     dependencies: deps,
     include_directories: include_dir,

--- a/meson.build
+++ b/meson.build
@@ -147,6 +147,7 @@ if tracy_dep.found()
     deps += tracy_dep
 endif
 
+
 python3 = find_program('python3', required: false)
 
 meson_proj = dependency('', required: false)
@@ -157,10 +158,27 @@ if python3.found() and get_option('website')
     c_args += ['-DHAVE_MESON_DOCS_H']
 endif
 
+
+muon_lib = library('muon',
+    lib_src,
+    dependencies: deps,
+    include_directories: include_dir,
+    link_args: link_args,
+    c_args: c_args,
+    cpp_args: c_args,
+)
+
+muon_dep = declare_dependency(
+    link_with: muon_lib,
+    dependencies: deps,
+    include_directories: include_dir,
+)
+
+
 muon = executable(
     'muon',
     src,
-    dependencies: deps,
+    dependencies: muon_dep,
     include_directories: include_dir,
     link_args: link_args,
     c_args: c_args,

--- a/meson.build
+++ b/meson.build
@@ -63,7 +63,7 @@ link_args = []
 
 if get_option('static')
     c_args += '-DMUON_STATIC'
-    link_args += '-static'
+    #link_args += '-static'
 endif
 
 cc = meson.get_compiler('c')

--- a/meson.build
+++ b/meson.build
@@ -173,6 +173,7 @@ muon_dep = declare_dependency(
     include_directories: include_dir,
 )
 
+if not meson.is_subproject()
 muon = executable(
     'muon',
     src,
@@ -185,4 +186,5 @@ muon = executable(
 )
 
 subdir('tests')
+endif
 subdir('doc')

--- a/meson.build
+++ b/meson.build
@@ -174,7 +174,6 @@ muon_dep = declare_dependency(
     include_directories: include_dir,
 )
 
-
 muon = executable(
     'muon',
     src,

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -4,19 +4,19 @@
 option(
     'libcurl',
     type: 'feature',
-    value: 'auto',
+    value: 'disabled',
     description: 'required for fetching wraps',
 )
 option(
     'libarchive',
     type: 'feature',
-    value: 'auto',
+    value: 'disabled',
     description: 'required for extracting wrap archives',
 )
 option(
     'libpkgconf',
     type: 'feature',
-    value: 'auto',
+    value: 'disabled',
     description: 'required for dependency discovery with pkg-config files',
 )
 option(
@@ -35,13 +35,13 @@ option(
 option(
     'static',
     type: 'boolean',
-    value: false,
+    value: true,
     description: 'build a static muon executable',
 )
 option(
     'docs',
     type: 'feature',
-    value: 'auto',
+    value: 'disabled',
     description: 'build documentation',
 )
 option(
@@ -53,7 +53,7 @@ option(
 option(
     'tracy',
     type: 'feature',
-    value: 'auto',
+    value: 'disabled',
     description: 'whether to enable tracy',
 )
 option(

--- a/src/datastructures/hash.c
+++ b/src/datastructures/hash.c
@@ -180,7 +180,7 @@ resize(struct hash *h, uint32_t newcap)
 		.load = h->load,
 		.max_load = (uint32_t)((float)newcap * LOAD_FACTOR),
 
-		.hash_func = h->hash_func_,
+		.hash_func = h->hash_func,
 		.keycmp = h->keycmp,
 	};
 

--- a/src/datastructures/hash.c
+++ b/src/datastructures/hash.c
@@ -180,7 +180,7 @@ resize(struct hash *h, uint32_t newcap)
 		.load = h->load,
 		.max_load = (uint32_t)((float)newcap * LOAD_FACTOR),
 
-		.hash_func = h->hash_func,
+		.hash_func = h->hash_func_,
 		.keycmp = h->keycmp,
 	};
 

--- a/src/formats/ini.c
+++ b/src/formats/ini.c
@@ -129,6 +129,9 @@ ini_reparse(const char *path, const struct source *src, char *buf, inihcb cb, vo
 bool
 ini_parse(const char *path, struct source *src, char **buf, inihcb cb, void *octx)
 {
+	if (src->src) {
+		fs_source_destroy(src);
+	}
 	if (!fs_read_entire_file(path, src)) {
 		return false;
 	}

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Stone Tickle <lattis@mochiro.moe>
 # SPDX-License-Identifier: GPL-3.0-only
 
-src = files(
+lib_src = files(
     'backend/backend.c',
     'backend/common_args.c',
     'backend/ninja.c',
@@ -99,13 +99,17 @@ src = files(
     'wrap.c',
 )
 
+src = files(
+    'main.c',
+)
+
 deps = []
 
 subdir('platform')
-src += platform_sources
+lib_src += platform_sources
 
 # version information
-src += configure_file(
+lib_src += configure_file(
     configuration: version_info,
     input: 'version.c.in',
     output: 'version.c',
@@ -113,11 +117,11 @@ src += configure_file(
 
 # embedded scripts
 subdir('script')
-src += script_sources
+lib_src += script_sources
 
 # dependencies
 subdir('external')
-src += dep_sources
+lib_src += dep_sources
 deps += external_deps
 
 if get_option('ui').enabled()


### PR DESCRIPTION
Do not install muon when building mesonlsp.

It appears that 8bc475513c9f02b978a9772137f432734db21b36 was already meant to rectify this issue, but that commit removes a single empty line instead of implementing anything.